### PR TITLE
Remove redundant Net::Telnet->open()

### DIFF
--- a/lib/Net/CLI/Interact/Transport/Role/ConnectCore.pm
+++ b/lib/Net/CLI/Interact/Transport/Role/ConnectCore.pm
@@ -23,8 +23,6 @@ sub connect_core {
 sub _via_native {
     my $self = shift;
     my $t = Net::Telnet->new(Cmd_remove_mode => 1, @_);
-    $t->open()
-        or die "failed to open Net::Telnet connection to target device.";
     return $t;
 }
 


### PR DESCRIPTION
The constructor in Net::Telnet already calls open() if the Host
parameter has been passed in. In addition, the constructor already dies
if it fails to connect.

This additional call to open() causes some Cisco devices (an old 2900XL
in my case) to close the new connection immediately after connect. We then get
stuck in an infinite loop in Net/CLI/Interact/Role/Prompt.pm:find_prompt()
