### PR TITLE
Allow square brackets in bash prompts

### DIFF
--- a/lib/Net/CLI/Interact/phrasebook/unix/bash/pb
+++ b/lib/Net/CLI/Interact/phrasebook/unix/bash/pb
@@ -5,10 +5,10 @@ prompt pass
     match /password(?: for \w+)?: $/
 
 prompt generic
-    match /\w+@.+\$ $/
+    match /(?:\[)?\w+@.+(?:\])?\$ $/
 
 prompt privileged
-    match /^root@.+# $/
+    match /^(?:\[)?root@.+(?:\])?# $/
 
 macro begin_privileged
     send sudo su -


### PR DESCRIPTION
Modify the generic and privileged prompts to match content enclosed in
square brackets.

Generic prompt example:
  [username@host ~]$

Privileged prompt example:
  [root@host ~]#
