### PR TITLE
remove ANSI terminal codes from CLI response

### DIFF
--- a/lib/Net/CLI/Interact/Transport/Base.pm
+++ b/lib/Net/CLI/Interact/Transport/Base.pm
@@ -5,6 +5,7 @@ package Net::CLI::Interact::Transport::Base;
 
 use Moo;
 use MooX::Types::MooseLike::Base qw(InstanceOf);
+with "Net::CLI::Interact::Transport::Role::EscapeANSI";
 
 BEGIN {
     sub is_win32 { return ($^O eq 'MSWin32') }

--- a/lib/Net/CLI/Interact/Transport/Role/EscapeANSI.pm
+++ b/lib/Net/CLI/Interact/Transport/Role/EscapeANSI.pm
@@ -1,0 +1,30 @@
+package Net::CLI::Interact::Transport::Role::EscapeANSI;
+use strict;
+use warnings FATAL => 'all';
+use Moo::Role;
+my %ansi_codes = (
+    1  => q/\x1b\[\d+;\d+H/, # code_position_cursor
+    3  => q/\x1b\[\?25h/, #code_show_cursor
+    4  => q/\x1b\x45/, #code_next_line
+    5  => q/\x1b\[2K/, #code_erase_line
+    6  => q/\x1b\[K/, #code_erase_start_line
+    7  => q/\x1b\[\d+;\d+r/, #code_enable_scroll
+    68 => q/\e\[\??\d+(;\d+)*[A-Za-z]/, #VLZ addon from ytti/oxidized
+);
+
+# https://github.com/ollyg/Net-CLI-Interact/issues/22
+around 'buffer' => sub {
+        my $orig = shift;
+        my $buffer = ($orig->(@_) || '');
+        #        my $buffer="buffer substituted";
+        # remove control characters
+        $buffer =~ s/[\000-\010\013\014\016-\032\034-\037]//g;
+        # strip ANSI terminal codes
+        foreach my $code (sort keys %ansi_codes) {
+            my $to = '';
+            $to = "\n" if ($code == 4); # CODE_NEXT_LINE must substitute with '\n'
+            $buffer =~ s/$ansi_codes{$code}/$to/g;
+        }
+        return $buffer;
+    };
+1;


### PR DESCRIPTION
Yours idea to use around for buffer is very good, except it doesn't work
as mentioned here [here](https://stackoverflow.com/questions/21523948/moose-before-and-inheritance)

> The before modifier becomes part of the method itself. When you override the method in your subclass, you're overriding the entirety of the superclass' behavior - that is, you're overriding the method modifier as well.

So all classes which overrides buffer override `around` too
As suggested, I used role and it works for me (Telnet at least).