### PR TITLE
Add macro for "fsck" command on Cisco IOS

### DIFF
--- a/lib/Net/CLI/Interact/phrasebook/cisco/ios/pb
+++ b/lib/Net/CLI/Interact/phrasebook/cisco/ios/pb
@@ -3,3 +3,7 @@
 
 macro paging
     send terminal length %s
+
+macro fsck
+    send fsck
+    follow /\[confirm\]/ with "\n"


### PR DESCRIPTION
Hi Oliver, I added this macro to provide fsck capability on IOS. Currently using this because we have loads of Cisco 3600 series access points with filesystem corruption.