### PR TITLE
Add macro for Cisco WLC to configure AP syslog host

### DIFF
--- a/share/phrasebook/cisco/wlc/pb
+++ b/share/phrasebook/cisco/wlc/pb
@@ -10,3 +10,8 @@ macro disable_paging
 macro enable_paging
     send config paging enable
 
+macro config_ap_syslog_host_global
+    send config ap syslog host global %s
+    follow /Are you sure/ with y\n
+    match generic
+


### PR DESCRIPTION
Configuring AP syslog hosts through Cisco WLC requires confirmation, so I created a simple macro for it. Tested against several WLC 5508 controllers on three different software versions.