### PR TITLE
Improve phrasebook for HP

### DIFF
--- a/share/phrasebook/cisco/hp/pb
+++ b/share/phrasebook/cisco/hp/pb
@@ -20,3 +20,23 @@ macro enable_paging
 macro disable_paging
     send no page
 
+macro begin_privileged
+    send enable
+    match user or pass or privileged
+
+macro end_privileged
+    send exit
+    match generic
+
+macro begin_configure
+    send configure terminal
+    match configure
+
+macro end_configure
+    send end
+    match privileged
+
+macro disconnect
+    send logout
+    match generic
+


### PR DESCRIPTION
Improve "hp" phrasebook for HP ProCurve / Aruba AOS-S devices

- Leave configure mode via "end"
- Leave privileged mode via "exit" - "disable" doesn't exist
- Logout using "logout"