### PR TITLE
phrasebook: Fix password prompt

### DIFF
--- a/share/phrasebook/cisco/foundry/pb
+++ b/share/phrasebook/cisco/foundry/pb
@@ -14,7 +14,7 @@ prompt user
     match /Login Name: ?$/
 
 prompt pass
-    match /Password: ?$/
+    match /[Pp]assword: ?$/
 
 macro begin_configure
     send configure terminal


### PR DESCRIPTION
Some old turboiron (SSH) use prompt in lowercase:

`password: `

fix #49